### PR TITLE
feat(node): support node versions < 10 for lighthouse

### DIFF
--- a/src/Audit.js
+++ b/src/Audit.js
@@ -2,6 +2,15 @@
 'use strict'
 
 const debug = require('debug')('is-website-vulnerable')
+
+const nodeVersion = process.versions['node']
+const nodeVersionMajor = nodeVersion.split('.')[0]
+debug(`detected Node.js version: ${nodeVersionMajor}`)
+if (nodeVersionMajor < 10) {
+  debug('setting global URL variable')
+  global.URL = require('url').URL
+}
+
 const lighthouse = require('lighthouse')
 const chromeLauncher = require('chrome-launcher')
 


### PR DESCRIPTION
## Description

Add workaround support for Node.js versions lower than 10 (i.e: 9 and 8) which support async and template strings but require special treatment for lighthouse.

## Types of changes

Defines `URL` as a global variable for Lighthouse on older Node.js versions

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Fixes https://github.com/lirantal/is-website-vulnerable/issues/14

