### PR TITLE
feat(lib): Trim snyk url from utm_* query params on the results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ typings/
 .dynamodb/
 
 package-lock.json
+
+# IDE
+.vscode

--- a/__tests__/Utils.test.js
+++ b/__tests__/Utils.test.js
@@ -47,4 +47,12 @@ describe('Utils', () => {
     const url = 'https://google.com?version=1&minor=5&source=github'
     expect(Utils.trimUtmParams(url)).toEqual(url)
   })
+  test('trimUtmParams function with url and auth given with no utm query params but with other query params', async () => {
+    const url = 'https://user:pass@google.com?version=1&minor=5&source=github'
+    expect(Utils.trimUtmParams(url)).toEqual(url)
+  })
+  test('trimUtmParams function with hash given with no utm query params but with other query params', async () => {
+    const url = 'https://user:pass@google.com?version=1&minor=5&source=github#hash'
+    expect(Utils.trimUtmParams(url)).toEqual(url)
+  })
 })

--- a/__tests__/Utils.test.js
+++ b/__tests__/Utils.test.js
@@ -15,4 +15,36 @@ describe('Utils', () => {
     const url = 'https://google.com'
     expect(Utils.parseUrl(url)).toEqual('https://google.com')
   })
+
+  test('trimUtmParams function with no url', async () => {
+    const url = undefined
+    expect(Utils.trimUtmParams(url)).toEqual(undefined)
+  })
+
+  test('trimUtmParams function with url given with no utm query params', async () => {
+    const url = 'https://google.com'
+    expect(Utils.trimUtmParams(url)).toEqual(url)
+  })
+
+  test('trimUtmParams function with url given with utm query params', async () => {
+    const url =
+      'https://snyk.io/vuln/npm:jquery?lh=3.3.1&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit'
+    expect(Utils.trimUtmParams(url)).toEqual('https://snyk.io/vuln/npm:jquery?lh=3.3.1')
+  })
+
+  test('trimUtmParams function with url given with utm query params in uppercase', async () => {
+    const url =
+      'https://snyk.io/vuln/npm:jquery?lh=3.3.1&UTM_SOURCE=lighthouse&utm_medium=ref&UTM_CAMPAIGN=audit'
+    expect(Utils.trimUtmParams(url)).toEqual('https://snyk.io/vuln/npm:jquery?lh=3.3.1')
+  })
+
+  test('trimUtmParams function with url given with utm query params with custom UTM', async () => {
+    const url = 'https://snyk.io/vuln/npm:jquery?lh=3.3.1&utm_something=123'
+    expect(Utils.trimUtmParams(url)).toEqual('https://snyk.io/vuln/npm:jquery?lh=3.3.1')
+  })
+
+  test('trimUtmParams function with url given with no utm query params but with other query params', async () => {
+    const url = 'https://google.com?version=1&minor=5&source=github'
+    expect(Utils.trimUtmParams(url)).toEqual(url)
+  })
 })

--- a/src/RenderConsole.js
+++ b/src/RenderConsole.js
@@ -3,6 +3,7 @@
 'use strict'
 
 const chalk = require('chalk')
+const { trimUtmParams } = require('./Utils')
 
 module.exports = class RenderConsole {
   constructor(scanResults, showLibs) {
@@ -96,7 +97,7 @@ module.exports = class RenderConsole {
     ⎜ ${this.formatSeverityChart(vulnItem.highestSeverity)} ${chalk
       .bgHex(this.formatSeverityColor(vulnItem.highestSeverity))
       .bold(` ${vulnItem.vulnCount} `)} vulnerabilities
-    ⎣ ${chalk.hex('#4b45a1')('▶')}︎ ${vulnItem.detectedLib.url}`
+    ⎣ ${chalk.hex('#4b45a1')('▶')}︎ ${trimUtmParams(vulnItem.detectedLib.url)}`
   }
 
   formatSeverityColor(severity) {

--- a/src/RenderJson.js
+++ b/src/RenderJson.js
@@ -2,6 +2,8 @@
 /* eslint-disable indent */
 'use strict'
 
+const { trimUtmParams } = require('./Utils')
+
 module.exports = class RenderJson {
   constructor(scanResults) {
     this.data = scanResults
@@ -53,7 +55,7 @@ module.exports = class RenderJson {
       library: vulnItem.detectedLib.text,
       severity: vulnItem.highestSeverity,
       vulnerabilitiesCount: vulnItem.vulnCount,
-      url: vulnItem.detectedLib.url
+      url: trimUtmParams(vulnItem.detectedLib.url)
     }
     return output
   }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,4 +1,6 @@
 const url = require('url')
+//Removing utm_* parameters from URL
+const REGEX_UTM_TRIMMER = /(\?)utm[^&]*(?:&utm[^&]*)*&(?=(?!utm[^\s&=]*=)[^\s&=]+=)|\?utm[^&]*(?:&utm[^&]*)*$|&utm[^&]*/gi
 
 module.exports = {
   parseUrl: function(urlToScan) {
@@ -10,5 +12,10 @@ module.exports = {
     }
 
     return urlToScan
+  },
+  trimUtmParams: function(urlToTrim) {
+    if (urlToTrim === undefined) return urlToTrim
+
+    return urlToTrim.replace(REGEX_UTM_TRIMMER, '$1')
   }
 }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,5 +1,6 @@
 const url = require('url')
-//Removing utm_* parameters from URL
+// Removing utm_* parameters from URL
+// eslint-disable-next-line security/detect-unsafe-regex
 const REGEX_UTM_TRIMMER = /(\?)utm[^&]*(?:&utm[^&]*)*&(?=(?!utm[^\s&=]*=)[^\s&=]+=)|\?utm[^&]*(?:&utm[^&]*)*$|&utm[^&]*/gi
 
 module.exports = {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,7 +1,4 @@
 const url = require('url')
-// Removing utm_* parameters from URL
-// eslint-disable-next-line security/detect-unsafe-regex
-const REGEX_UTM_TRIMMER = /(\?)utm[^&]*(?:&utm[^&]*)*&(?=(?!utm[^\s&=]*=)[^\s&=]+=)|\?utm[^&]*(?:&utm[^&]*)*$|&utm[^&]*/gi
 
 module.exports = {
   parseUrl: function(urlToScan) {
@@ -17,6 +14,19 @@ module.exports = {
   trimUtmParams: function(urlToTrim) {
     if (urlToTrim === undefined) return urlToTrim
 
-    return urlToTrim.replace(REGEX_UTM_TRIMMER, '$1')
+    // eslint-disable-next-line node/no-deprecated-api
+    const parsedUrl = url.parse(urlToTrim)
+    const queryParams = parsedUrl.query ? parsedUrl.query.split('&') : []
+    const nonUtmQueryParams = []
+    queryParams.forEach(queryParam => {
+      if (!queryParam.toLowerCase().startsWith('utm_')) {
+        nonUtmQueryParams.push(queryParam)
+      }
+    })
+    const auth = parsedUrl.auth ? `${parsedUrl.auth}@` : ''
+    const pathname = parsedUrl.pathname !== '/' ? parsedUrl.pathname : ''
+    const query = nonUtmQueryParams.length > 0 ? `?${nonUtmQueryParams.join('&')}` : ''
+    const hash = parsedUrl.hash ? parsedUrl.hash : ''
+    return `${parsedUrl.protocol}//${auth}${parsedUrl.host}${pathname}${query}${hash}`
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#35 ](https://github.com/lirantal/is-website-vulnerable/issues/35)
## Motivation and Context
Removing utm_* query params of snyk analytics
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Adding unit tests for different Urls with different scenarios of query params
Running is-website-vulnerable https://go.microsoft.com and check the snyk url is printed without utm_* query params
Running is-website-vulnerable https://go.microsoft.com --json and check the snyk url is printed without utm_* query params
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun

![Alt Text](http://giphygifs.s3.amazonaws.com/media/bHoFqabfGJLpu/giphy.gif)