### PR TITLE
fix(cli): disable CLI animations on windows

### DIFF
--- a/bin/is-website-vulnerable.js
+++ b/bin/is-website-vulnerable.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-process-exit */
 'use strict'
 
+const os = require('os')
 const debug = require('debug')('is-website-vulnerable')
 const argv = require('yargs').argv
 const { Audit, RenderConsole, RenderJson, Utils } = require('../index')
@@ -27,8 +28,20 @@ if (Utils.hasDevice(argv)) {
   opts.emulatedFormFactor = Utils.parseDevice(argv)
 }
 
+const isWindows = os.type() === 'Windows_NT'
+const isJson = !!argv.json
+const showProgressBar = !isJson && !isWindows
+
+if (isWindows && !isJson) {
+  console.log('Please wait, scanning the website (can take up to a minute)...')
+}
+
+debug(`detecting isWindows: ${isWindows}`)
+debug(`detecting isJson: ${isJson}`)
+debug(`showing progress bar: ${isWindows}`)
+
 const audit = new Audit()
-const showProgressBar = !argv.json
+
 audit
   .scanUrl(url, opts, showProgressBar)
   .then(results => {

--- a/src/Audit.js
+++ b/src/Audit.js
@@ -24,8 +24,6 @@ module.exports = class Audit {
   }
 
   async scanUrl(url, optflags = {}, progress = false) {
-    // Start chrome-launcher Spinner
-
     // chrome-launcher Spinner
     const spinner1 = new Ora({
       text: chalk.cyan('Setting up a chrome instance'),


### PR DESCRIPTION
# Description

If windows is detected as the OS we disable the progress bar as it may cause prompt rendering issues

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
Fixes #45 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Windows users have been suffering from freezed CLIs and scans not happening probably due to drawing the animatinos, since a --json works just fine (as animations are disabled in this one as well)

