### PR TITLE
docs(browser-version): added a warning about the version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Using Node.js's `npx` to run a one-off scan of a website:
 npx is-website-vulnerable https://example.com [--json] [--js-lib] [--mobile|--desktop] [--chromePath]
 ```
 
+:warning: A modern version of Chrome is assumed to be available when using `is-website-vulnerable`. It may not be safe to assume that this is satisfied automatically on some CI services. For example, [additional configuration](https://docs.travis-ci.com/user/chrome#selecting-a-chrome-version) is necessary for [Travis CI](https://travis-ci.com/).
+
 # Install
 
 You can install globally via:


### PR DESCRIPTION
## Related Issue

based on conversation from https://github.com/travi/javascript-scaffolder/issues/24#issuecomment-560164100

happy to tie to an issue that is local to this project if you'd prefer
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

i ran into [an issue when i pushed to travis](https://travis-ci.org/travi-org/matt.travi.org/jobs/619107136#L644-L650). a quick search for the error [suggested that the installed chrome was too old](https://github.com/puppeteer/puppeteer/issues/1271) which was easily remedied by [specifying a newer version](https://docs.travis-ci.com/user/chrome#selecting-a-chrome-version), but i could see that tripping up some users.

## How Has This Been Tested?

builds after adding the browser version have been working as expected, for example: https://travis-ci.org/travi-org/matt.travi.org/builds/619116313#L655-L662

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
