### PR TITLE
build: prune devDeps from shrinkwrap prior to release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node: [ '12', '10' ]
+        node: ['12', '10']
     name: Node ${{ matrix.node }} (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
     steps:
@@ -27,7 +27,7 @@ jobs:
         run: codecov
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-        
+
   release:
     name: do semantic release
     runs-on: 'ubuntu-latest'
@@ -39,6 +39,8 @@ jobs:
           node-version: '10'
       - name: install dependencies
         run: npm install --ignore-engines
+      - name: prune devDeps from shrinkwrap file
+        run: npx lockfile-prune npm-shrinkwrap.json
       - name: release
         run: npm run semantic-release
         env:


### PR DESCRIPTION
## Description

Prune devDeps from shrinkwrap prior to release, as they add to the file size and aren't necessary anyway.

## Types of changes

Update the build process

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Fixes #54 

