### PR TITLE
fix(cli): properly spell authentication in code

### DIFF
--- a/__tests__/Utils.test.js
+++ b/__tests__/Utils.test.js
@@ -84,37 +84,37 @@ describe('Utils', () => {
     expect(Utils.hasDevice(argv)).toEqual(true)
   })
 
-  test('hasAutentication & parseAutentication with none flag', async () => {
+  test('hasAuthentication & parseAuthentication with no flag', async () => {
     const argv = {}
-    expect(Utils.parseAutentication(argv)).toEqual({})
-    expect(Utils.hasAutentication(argv)).toEqual(false)
+    expect(Utils.parseAuthentication(argv)).toEqual({})
+    expect(Utils.hasAuthentication(argv)).toEqual(false)
   })
 
-  test('hasAutentication & parseAutentication with cookie flag', async () => {
+  test('hasAuthentication & parseAuthentication with cookie flag', async () => {
     const argv = { cookie: 'This is the COOKIE content' }
-    expect(Utils.parseAutentication(argv)).toEqual({
+    expect(Utils.parseAuthentication(argv)).toEqual({
       Cookie: 'This is the COOKIE content'
     })
-    expect(Utils.hasAutentication(argv)).toEqual(true)
+    expect(Utils.hasAuthentication(argv)).toEqual(true)
   })
 
-  test('hasAutentication & parseAutentication with token flag', async () => {
+  test('hasAuthentication & parseAuthentication with token flag', async () => {
     const argv = { token: 'This is the TOKEN content' }
-    expect(Utils.parseAutentication(argv)).toEqual({
+    expect(Utils.parseAuthentication(argv)).toEqual({
       Authorization: 'Bearer This is the TOKEN content'
     })
-    expect(Utils.hasAutentication(argv)).toEqual(true)
+    expect(Utils.hasAuthentication(argv)).toEqual(true)
   })
 
-  test('hasAutentication & parseAutentication with token and cookie flags', async () => {
+  test('hasAuthentication & parseAuthentication with token and cookie flags', async () => {
     const argv = {
       cookie: 'This is the COOKIE content',
       token: 'This is the TOKEN content'
     }
-    expect(Utils.parseAutentication(argv)).toEqual({
+    expect(Utils.parseAuthentication(argv)).toEqual({
       Cookie: 'This is the COOKIE content',
       Authorization: 'Bearer This is the TOKEN content'
     })
-    expect(Utils.hasAutentication(argv)).toEqual(true)
+    expect(Utils.hasAuthentication(argv)).toEqual(true)
   })
 })

--- a/bin/is-website-vulnerable.js
+++ b/bin/is-website-vulnerable.js
@@ -23,8 +23,8 @@ function getLighthouseOptions() {
     lighthouseOpts.emulatedFormFactor = Utils.parseDevice(argv)
   }
 
-  if (Utils.hasAutentication(argv)) {
-    lighthouseOpts.extraHeaders = Utils.parseAutentication(argv)
+  if (Utils.hasAuthentication(argv)) {
+    lighthouseOpts.extraHeaders = Utils.parseAuthentication(argv)
   }
 
   const { chromePath } = argv

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -43,7 +43,7 @@ module.exports = {
   hasDevice: function(argv) {
     return argv.mobile || argv.desktop || argv.none || false
   },
-  parseAutentication: function(argv) {
+  parseAuthentication: function(argv) {
     const extraHeaders = {}
     if (argv.cookie) {
       extraHeaders.Cookie = argv.cookie
@@ -55,7 +55,7 @@ module.exports = {
 
     return extraHeaders
   },
-  hasAutentication: function(argv) {
+  hasAuthentication: function(argv) {
     return ['cookie', 'token'].some(prop => Object.hasOwnProperty.call(argv, prop))
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the typo of **authentication** in the code-base.
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
Closes #77 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
**Authentication** was misspelled as **autentication** in many places of code.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
All the existing unit tests are passing.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun
![image](https://user-images.githubusercontent.com/37476886/89708526-bcda5080-d995-11ea-8b7b-bbbfb05b8c2f.png)
